### PR TITLE
fix: protect /dashboard routes with Clerk middleware

### DIFF
--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,6 +1,10 @@
-import { clerkMiddleware } from "@clerk/nextjs/server";
+import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
 
-export default clerkMiddleware();
+const isProtectedRoute = createRouteMatcher(["/dashboard(.*)"]);
+
+export default clerkMiddleware(async (auth, req) => {
+  if (isProtectedRoute(req)) await auth.protect();
+});
 
 export const config = {
   matcher: [


### PR DESCRIPTION
Redirect unauthenticated users to sign-in when accessing /dashboard or any subpage, instead of throwing an Unauthorized error.