### PR TITLE
feat: enable dark mode site-wide

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -8,6 +8,7 @@ import {
   UserButton,
 } from "@clerk/nextjs";
 import { Geist, Geist_Mono } from "next/font/google";
+import { Button } from "@/components/ui/button";
 import "./globals.css";
 
 const geistSans = Geist({
@@ -32,21 +33,17 @@ export default function RootLayout({
 }>) {
   return (
     <ClerkProvider>
-      <html lang="en">
+      <html lang="en" className="dark">
         <body
           className={`${geistSans.variable} ${geistMono.variable} antialiased`}
         >
           <header className="flex items-center justify-end gap-4 p-4">
             <SignedOut>
               <SignInButton mode="modal">
-                <button className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm transition-colors hover:bg-gray-50">
-                  Sign in
-                </button>
+                <Button variant="outline">Sign in</Button>
               </SignInButton>
               <SignUpButton mode="modal">
-                <button className="rounded-md bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm transition-colors hover:bg-indigo-500">
-                  Sign up
-                </button>
+                <Button>Sign up</Button>
               </SignUpButton>
             </SignedOut>
             <SignedIn>


### PR DESCRIPTION
Add dark class to the root html element to activate the dark mode CSS variables already defined in globals.css. Replace hardcoded button styles in the header with shadcn/ui Button components so they properly adapt to the dark theme.

Closes #7